### PR TITLE
Reuse created transport to fix bug when signing.

### DIFF
--- a/src/LedgerSigner.js
+++ b/src/LedgerSigner.js
@@ -9,11 +9,20 @@ export class LedgerSigner {
     this.hdPath = hdPath
     this.transportInterface = transportInterface
     this.address = null
+    this.transport = null
   }
 
   obtainAppInterface() {
-    return this.transportInterface.create()
-      .then((transport) => new AppBtc(transport))
+    if (this.transport) {
+      return Promise.resolve(this.transport)
+    } else {
+      return this.transportInterface.create()
+        .then((transport) => {
+          transport = new AppBtc(transport)
+          this.transport = transport
+          return transport
+        })
+    }
   }
 
   // Return the public key string


### PR DESCRIPTION
Reuses the created transport interface instead of creating a new one every time. Fixes a fatal error when signing transactions.